### PR TITLE
Add initial FastAPI backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,17 @@ Ava is an interactive, AI-driven application tailored to help young children wit
 - Improved conversational clarity and increased frequency of speech
 - Clearer emotional recognition demonstrated by the child
 - Increased successful potty-training interactions
+
+## Backend Setup
+The backend uses **FastAPI** (Python 3.12). To install dependencies, create and activate a virtual environment and run:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Start the development server with:
+
+```bash
+uvicorn app.main:app --reload --app-dir backend
+```
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="Ava Backend")
+
+# Allow cross-origin requests during development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/")
+async def read_root():
+    """Health check endpoint"""
+    return {"message": "Ava backend is running"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+langchain
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- create backend app directory for FastAPI
- add minimal main.py with health check endpoint
- include requirements.txt for backend dependencies
- document how to set up and run the backend

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `python3 - <<'EOF'
from backend.app.main import app
print(app.title)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6840afda6bc0832795445efd38e5f57a